### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/furimas_controller.rb
+++ b/app/controllers/furimas_controller.rb
@@ -19,6 +19,9 @@ class FurimasController < ApplicationController
     end
   end
     
+  def show
+    @furima = Furima.find(params[:id])
+  end
   
 
 

--- a/app/models/furima.rb
+++ b/app/models/furima.rb
@@ -3,7 +3,7 @@ class Furima < ApplicationRecord
   belongs_to :category
   belongs_to :condition
   belongs_to :delivery_charge
-  belongs_to :Prefecture
+  belongs_to :prefecture
   belongs_to :time_required
   belongs_to :user
   has_one_attached :image

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -20,4 +20,5 @@ class Prefecture < ActiveHash::Base
   
   include ActiveHash::Associations
   has_many :furimas
+  
 end

--- a/app/views/furimas/index.html.erb
+++ b/app/views/furimas/index.html.erb
@@ -131,7 +131,7 @@
 
     <% @furimas.each do |furima| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to furima_path(furima.id) do %>
         <div class='item-img-content'>
           <%= image_tag furima.image, class: "item-img" %>
 

--- a/app/views/furimas/show.html.erb
+++ b/app/views/furimas/show.html.erb
@@ -7,23 +7,23 @@
       <%= "商品名" %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @furima.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
+      <%#<div class="sold-out">
         <span>Sold Out!!</span>
       </div>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+       <%=  @furima.price %>
       </span>
       <span class="item-postage">
         <%= "配送料負担" %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% if user_signed_in? %>
 
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
@@ -34,7 +34,7 @@
     <%# //商品が売れていない場合はこちらを表示しましょう %>
 
 
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% end %>
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>
@@ -43,27 +43,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @furima.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @furima.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @furima.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @furima.delivery_charge.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @furima.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @furima.time_required.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/furimas/show.html.erb
+++ b/app/views/furimas/show.html.erb
@@ -4,7 +4,7 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @furima.product %>
     </h2>
     <div class="item-img-content">
       <%= image_tag @furima.image ,class:"item-box-img" %>
@@ -16,28 +16,28 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-       <%=  @furima.price %>
+       <%= "¥#{@furima.price}" %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @furima.delivery_charge.name %>
       </span>
     </div>
 
     <% if user_signed_in? %>
 
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+      <p class="or-text">or</p>
+      <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
 
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
+      <% unless current_user.id == @furima.user_id %>
+      <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+      <% end %>
 
 
     <% end %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @furima.content %></span>
     </div>
     <table class="detail-table">
       <tbody>

--- a/app/views/furimas/show.html.erb
+++ b/app/views/furimas/show.html.erb
@@ -23,7 +23,7 @@
       </span>
     </div>
 
-    <% if user_signed_in? %>
+    <% if user_signed_in? && current_user.id == @furima.user.id %>
 
       <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
@@ -102,9 +102,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item"><%= @furima.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>


### PR DESCRIPTION
# what
商品詳細ページの実装

# why
出品された商品の詳細を閲覧できるようにするため

- ログイン状態の出品者が、自身の出品した販売中商品の詳細ページへ遷移した動画:https://gyazo.com/97439376357f442872e3f9fcfeab5e14
- ログイン状態の出品者以外のユーザーが、他者の出品した販売中商品の詳細ページへ遷移した動画:https://gyazo.com/54f750fa67f7b7a5f987f7c8ca225745
- ログアウト状態のユーザーが、商品詳細ページへ遷移した動画:https://gyazo.com/2786e3163b4b4b31ac83580f57cc0814

現段階で商品購入機能が未実装のため、購入機能実装後でなければ実装できない機能は行っていません。
よろしくお願いいたします。