### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/furimas_controller.rb
+++ b/app/controllers/furimas_controller.rb
@@ -22,7 +22,19 @@ class FurimasController < ApplicationController
   def show
     @furima = Furima.find(params[:id])
   end
-  
+
+  def edit
+    @furima = Furima.find(params[:id])
+  end
+
+  def update
+    @furima = Furima.find(params[:id])
+    if @furima.update(furima_paramas)
+      redirect_to furima_path(@furima.id)
+    else
+      render :edit
+    end
+  end
 
 
   private

--- a/app/controllers/furimas_controller.rb
+++ b/app/controllers/furimas_controller.rb
@@ -1,6 +1,6 @@
 class FurimasController < ApplicationController
 
-  before_action :authenticate_user!, only: [:new, :create, ]#:edit, :delete]
+  before_action :authenticate_user!, only: [:new, :create, :edit,] #:delete]
   
   def index
     @furimas = Furima.order("created_at DESC")
@@ -25,6 +25,9 @@ class FurimasController < ApplicationController
 
   def edit
     @furima = Furima.find(params[:id])
+    unless @furima.user_id == current_user.id
+      redirect_to root_path
+    end
   end
 
   def update

--- a/app/controllers/furimas_controller.rb
+++ b/app/controllers/furimas_controller.rb
@@ -1,7 +1,7 @@
 class FurimasController < ApplicationController
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update] #:delete]
   before_action :set_furima, only: [:show, :edit, :update]
   before_action :set_edit, only: [:edit, :update]
-  before_action :authenticate_user!, only: [:new, :create, :edit, :update] #:delete]
   
   def index
     @furimas = Furima.order("created_at DESC")

--- a/app/controllers/furimas_controller.rb
+++ b/app/controllers/furimas_controller.rb
@@ -1,6 +1,7 @@
 class FurimasController < ApplicationController
-
-  before_action :authenticate_user!, only: [:new, :create, :edit,] #:delete]
+  before_action :set_furima, only: [:show, :edit, :update]
+  before_action :set_edit, only: [:edit, :update]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update] #:delete]
   
   def index
     @furimas = Furima.order("created_at DESC")
@@ -20,18 +21,12 @@ class FurimasController < ApplicationController
   end
     
   def show
-    @furima = Furima.find(params[:id])
   end
 
   def edit
-    @furima = Furima.find(params[:id])
-    unless @furima.user_id == current_user.id
-      redirect_to root_path
-    end
   end
 
   def update
-    @furima = Furima.find(params[:id])
     if @furima.update(furima_paramas)
       redirect_to furima_path(@furima.id)
     else
@@ -46,7 +41,15 @@ class FurimasController < ApplicationController
     params.require(:furima).permit(:product, :content, :price, :category_id, :condition_id, :delivery_charge_id, :prefecture_id, :time_required_id, :image).merge(user_id: current_user.id)
   end
 
+  def set_furima
+    @furima = Furima.find(params[:id])
+  end
 
+  def set_edit
+    unless @furima.user_id == current_user.id
+      redirect_to root_path
+    end
+  end
   
 
 end

--- a/app/views/furimas/edit.html.erb
+++ b/app/views/furimas/edit.html.erb
@@ -7,10 +7,10 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model:@furima,local: true do |f| %>
 
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
+    <%= render 'shared/error_messages', model: f.object %>
     <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
 
     <%# 商品画像 %>
@@ -23,7 +23,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /商品画像 %>
@@ -33,13 +33,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :product, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :content, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +52,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:condition_id, Condition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +73,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:delivery_charge_id, DeliveryCharge.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:time_required_id, TimeRequired.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +101,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>

--- a/app/views/furimas/edit.html.erb
+++ b/app/views/furimas/edit.html.erb
@@ -9,9 +9,9 @@ app/assets/stylesheets/items/new.css %>
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model:@furima,local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    
     <%= render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    
 
     <%# 商品画像 %>
     <div class="img-upload">

--- a/app/views/furimas/show.html.erb
+++ b/app/views/furimas/show.html.erb
@@ -25,7 +25,7 @@
 
     <% if user_signed_in? && current_user.id == @furima.user.id %>
 
-      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+      <%= link_to "商品の編集", edit_furima_path, method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
       <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
 


### PR DESCRIPTION
# what
出品された商品の情報を編集できるように実装

# why
出品された商品の情報に誤りがあった時に情報の編集ができるようにするため

- ログイン状態の出品者は、商品情報編集ページに遷移できる動画:https://gyazo.com/d5a2f58a779d952c9716fdcfc34630f6
- 正しく情報を記入すると、商品の情報を編集できる動画:https://gyazo.com/d8052ae7a9b5c74f8ea9d66e93014169
- 入力に問題のある状態では商品の情報は編集できず、エラーメッセージが出力される動画:https://gyazo.com/81a9462cc78b4bc48c62ce7ff619c4a1
- 何も編集せずに更新をしても画像無しの商品にならない動画:https://gyazo.com/1f9b27c833bd7d455588e76347200c85
- ログイン状態のユーザーであっても、URLを直接入力して出品していない商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画:https://gyazo.com/21c617d270b00b64b6edb475d58b9910
- ログアウト状態のユーザーは、URLを直接入力して商品情報編集ページへ遷移しようとすると、ログインページに遷移する動画:https://gyazo.com/e0cf27c498fdd5b169f614da52300bcf
- 商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画:https://gyazo.com/568efb0d99c47af5d28ba707e3b8b143

現段階で商品購入機能が未実装のため、購入機能実装後でなければ実装できない機能は行っていません。
よろしくお願いいたします。

